### PR TITLE
add configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+planning/Config.py

--- a/planning/Config.example.py
+++ b/planning/Config.example.py
@@ -1,0 +1,2 @@
+class Config:
+    BASE_URL = 

--- a/planning/Config.example.py
+++ b/planning/Config.example.py
@@ -1,2 +1,2 @@
 class Config:
-    BASE_URL = 
+    BASE_URL = "http://18.219.63.23"

--- a/planning/Controller.py
+++ b/planning/Controller.py
@@ -5,10 +5,11 @@ import requests
 import json
 import math
 from math import sqrt
+from Config import Config
 
-base = 'http://18.219.63.23/edge'
-
-post = 'http://18.219.63.23/post'
+conf = Config
+base = conf.BASE_URL + '/edge'
+post = conf.BASE_URL + '/post'
 
 class Controller:
 
@@ -34,18 +35,18 @@ class Controller:
     def deliver(self, delivery):
         id = delivery['id']
         data = {'state':   'IN_PROGRESS'}
-        r = requests.patch("http://18.219.63.23/development/delivery/" + str(id), json=data)
+        r = requests.patch(conf.BASE_URL + "/development/delivery/" + str(id), json=data)
         self.toTarget(delivery['from']['name'].lower())
         data = {'state':   'AWAITING_PICKUP'}
-        r = requests.patch("http://18.219.63.23/development/delivery/" + str(id), json=data)
+        r = requests.patch(conf.BASE_URL + "/development/delivery/" + str(id), json=data)
 
         data = {'state':   'IN_PROGRESS'}
-        r = requests.patch("http://18.219.63.23/development/delivery/" + str(id), json=data)
+        r = requests.patch(conf.BASE_URL + "/development/delivery/" + str(id), json=data)
         self.toTarget(delivery['to']['name'].lower())
         data = {'state':   'COMPLETED'}
-        r = requests.patch("http://18.219.63.23/development/delivery/" + str(id), json=data)
+        r = requests.patch(conf.BASE_URL + "/development/delivery/" + str(id), json=data)
 
-        r = requests.delete('http://18.219.63.23/development/delivery/' + str(id))
+        r = requests.delete(conf.BASE_URL + '/development/delivery/' + str(id))
 
 
     def toTarget(self, name):
@@ -125,7 +126,7 @@ class Controller:
         return frame
 
     def getDelivery(self):
-        url = "http://18.219.63.23/development/deliveries"
+        url = conf.BASE_URL + "/development/deliveries"
         r = requests.get(url)
         queue = json.loads(r.text)
         return queue[0]
@@ -136,7 +137,7 @@ class Controller:
         self.plan = self.toTarget(fro)
         #self.plan = self.planner.plan('YELLOW')
         instructions = self.pointConversion(self.plan)
-        url = "http://ec2-18-219-63-23.us-east-2.compute.amazonaws.com/edge/instructions"
+        url = conf.BASE_URL + "/edge/instructions"
         r = requests.post(url, json = instructions)
         print(r.text)
 

--- a/planning/Tracker.py
+++ b/planning/Tracker.py
@@ -2,7 +2,9 @@ import cv2
 import numpy as np
 import requests
 import math
+from Config import Config
 
+conf = Config
 class Tracker:
     def __init__(self, rd):
         self.robotDetector = rd
@@ -85,17 +87,17 @@ class Tracker:
 
     def go(self,correction):
         print("correction",correction)
-        post = 'http://18.219.63.23/flaskapp/post?onOff=1&turnAngle=0.0&correction='+str(correction)
+        post = conf.BASE_URL + '/flaskapp/post?onOff=1&turnAngle=0.0&correction='+str(correction)
         r = requests.get(post)
         #print("go",r.text)
 
     def stop(self):
-        post = 'http://18.219.63.23/flaskapp/post?onOff=0&turnAngle=0.0&correction=0'
+        post = conf.BASE_URL + '/flaskapp/post?onOff=0&turnAngle=0.0&correction=0'
         r = requests.get(post)
         #print("stop",r.text)
 
     def turn(self, d):
-        post = 'http://18.219.63.23/flaskapp/post?onOff=1&turnAngle='+str(d)+'&correction=0'
+        post = conf.BASE_URL + '/flaskapp/post?onOff=1&turnAngle='+str(d)+'&correction=0'
         r = requests.get(post)
         #print("turn",r.text)
 


### PR DESCRIPTION
Added a configuration file for the Vision, so we can tell the user how to the make the Vision point to their server.

To configure the server, all they need to do is copy `Config.example.py` into `Config.py`, and modify it so that the BASE_URL points to the right address of the server. This should be the local IP address of the machine running the server.